### PR TITLE
melt constraints

### DIFF
--- a/include/aspect/melt.h
+++ b/include/aspect/melt.h
@@ -420,16 +420,6 @@ namespace aspect
       void add_current_constraints(ConstraintMatrix &constraints);
 
       /**
-       * Copy the current constraints and store them in a private member
-       * variable so that we can use them later. This is necessary because
-       * we want to add the melt constraints, which depend on the solution
-       * of the porosity field, later on, after we have computed this solution.
-       * In this way, we only need to update the constraints matrix instead
-       * of computing all constraints again.
-       */
-      void save_constraints(ConstraintMatrix &constraints);
-
-      /**
        * Returns the entry of the private variable is_melt_cell_vector for the
        * cell given in the input, describing if we have melt transport in this
        * cell or not.

--- a/source/simulator/core.cc
+++ b/source/simulator/core.cc
@@ -786,7 +786,7 @@ namespace aspect
       restore_outflow_boundary_ids(boundary_id_offset);
 
     if (parameters.include_melt_transport)
-      melt_handler->add_current_constraints (current_constraints);
+      melt_handler->add_current_constraints (new_current_constraints);
 
     // let plugins add more constraints if they so choose, then close the
     // constraints object

--- a/source/simulator/core.cc
+++ b/source/simulator/core.cc
@@ -785,15 +785,14 @@ namespace aspect
     if (!boundary_composition_manager.allows_fixed_composition_on_outflow_boundaries())
       restore_outflow_boundary_ids(boundary_id_offset);
 
+    if (parameters.include_melt_transport)
+      melt_handler->add_current_constraints (current_constraints);
+
     // let plugins add more constraints if they so choose, then close the
     // constraints object
     signals.post_constraints_creation(*this, new_current_constraints);
 
     new_current_constraints.close();
-
-    // let the melt handler copy the constraints so that it can add its own constraints later on
-    if (parameters.include_melt_transport)
-      melt_handler->save_constraints (new_current_constraints);
 
     // Now check if the current_constraints we just computed changed from before. Do this before the melt handler
     // adds constraints for the melt cells, because they are allowed to change (and often do) without us having
@@ -849,8 +848,6 @@ namespace aspect
 #endif
 
     // let the melt handler add its constraints once before we solve the porosity system for the first time
-    if (time_step == 0 && parameters.include_melt_transport)
-      melt_handler->add_current_constraints (current_constraints);
   }
 
 

--- a/source/simulator/melt.cc
+++ b/source/simulator/melt.cc
@@ -1486,12 +1486,6 @@ namespace aspect
   MeltHandler<dim>::
   add_current_constraints(ConstraintMatrix &constraints)
   {
-    // First, fill the constraints matrix with the current constraints from the beginning
-    // of the time step (that do not include the "melt cell" contributions).
-    constraints.clear ();
-    constraints.reinit (this->introspection().index_sets.system_relevant_set);
-    constraints.merge (current_constraints);
-
     IndexSet nonzero_pc_dofs(this->introspection().index_sets.system_relevant_set.size());
 
     const QTrapez<dim> quadrature_formula;
@@ -1582,19 +1576,6 @@ namespace aspect
 
     // and constrain the remaining dofs (that are not in melt cells).
     constraints.add_lines(for_constraints);
-    constraints.close();
-  }
-
-
-  template <int dim>
-  void
-  MeltHandler<dim>::
-  save_constraints(ConstraintMatrix &constraints)
-  {
-    current_constraints.clear ();
-    current_constraints.reinit (this->introspection().index_sets.system_relevant_set);
-    current_constraints.merge (constraints);
-    current_constraints.close();
   }
 
 

--- a/source/simulator/solver_schemes.cc
+++ b/source/simulator/solver_schemes.cc
@@ -247,12 +247,14 @@ namespace aspect
     // set constraints for p_c if porosity is below a threshold
     if (nonlinear_iteration == 0 && parameters.include_melt_transport)
       {
-        melt_handler->add_current_constraints (current_constraints);
+        this->compute_current_constraints();
+        if (rebuild_sparsity_and_matrices)
+          {
+            setup_system_matrix (introspection.index_sets.system_partitioning);
+            setup_system_preconditioner (introspection.index_sets.system_partitioning);
 
-        setup_system_matrix (introspection.index_sets.system_partitioning);
-        setup_system_preconditioner (introspection.index_sets.system_partitioning);
-
-        rebuild_stokes_matrix = rebuild_stokes_preconditioner = true;
+            rebuild_stokes_matrix = rebuild_stokes_preconditioner = true;
+          }
       }
 
     assemble_stokes_system ();


### PR DESCRIPTION
- simplify logic of recomputing melt sparsity pattern
- Bonus: this should speed up melt computations because rebuild is only done if
melt cells change